### PR TITLE
Remove unescaped null chars

### DIFF
--- a/lib/importer.js
+++ b/lib/importer.js
@@ -129,7 +129,6 @@ var importChangesBatch = function(db, couchdb, concurrentDocLimit, changesLimit,
 
       // TODO when node supports destructuring use it:
       // var [docsToDelete, docsToDownload] = _.partition... etc
-
       var deletesAndModifications = _.partition(changes.results, function(result) {
         return result.deleted;
       });

--- a/lib/importer.js
+++ b/lib/importer.js
@@ -17,8 +17,11 @@ var NO_DATA_ERROR = 'queryResultErrorCode.noData';
 var deleteDocuments = function(db, docIdsToDelete) {
   if (docIdsToDelete && docIdsToDelete.length) {
     // PostgreSQL doesn't support \u0000 (null unicode) in queries
-    var deleteStmt = format(DELETE_STMT, docIdsToDelete).replace(/\u0000/g, '');
-    return db.query(deleteStmt);
+    docIdsToDelete = docIdsToDelete.map(function(id) {
+      return id.replace(/\u0000|\\+u0000/g, '');
+    });
+
+    return db.query(format(DELETE_STMT, docIdsToDelete));
   } else {
     return rsvp.Promise.resolve();
   }

--- a/lib/importer.js
+++ b/lib/importer.js
@@ -16,7 +16,9 @@ var NO_DATA_ERROR = 'queryResultErrorCode.noData';
 
 var deleteDocuments = function(db, docIdsToDelete) {
   if (docIdsToDelete && docIdsToDelete.length) {
-    return db.query(format(DELETE_STMT, docIdsToDelete));
+    // PostgreSQL doesn't support \u0000 (null unicode) in queries
+    var deleteStmt = format(DELETE_STMT, docIdsToDelete).replace(/\u0000/g, '');
+    return db.query(deleteStmt);
   } else {
     return rsvp.Promise.resolve();
   }
@@ -127,6 +129,7 @@ var importChangesBatch = function(db, couchdb, concurrentDocLimit, changesLimit,
 
       // TODO when node supports destructuring use it:
       // var [docsToDelete, docsToDownload] = _.partition... etc
+
       var deletesAndModifications = _.partition(changes.results, function(result) {
         return result.deleted;
       });

--- a/tests/int/index.js
+++ b/tests/int/index.js
@@ -269,5 +269,28 @@ describe('couch2pg', function() {
         throw new Error(err);
       });
     });
+
+    it('should handle a doc update', function() {
+      var doc;
+      return couchdb
+        .put({
+          _id: '54contact:person:create\u00004form:contact:person:create',
+          data: '\u00004form:contact:person:create\u0000fndjskf'
+        })
+        .then(function(result) {
+          doc = result;
+          return itRunsSuccessfully();
+        })
+        .then(function() {
+          doc.data += 'updated';
+          return couchdb.put(doc);
+        })
+        .then(itRunsSuccessfully)
+        .catch(function(err) {
+          console.log(err);
+          throw new Error(err);
+        });
+
+    });
   });
 });

--- a/tests/int/index.js
+++ b/tests/int/index.js
@@ -252,7 +252,7 @@ describe('couch2pg', function() {
 
     it('should handle documents with \u0000 in their IDs, or sneakier times 2', function() {
       return couchdb.put({
-        _id: '54collect_off\\\u00004form:collect_off\\\\u0000\\\\u0000',
+        _id: '54collect_off\\\u00004form:collect_off\\\\u0000\\\\u0000no-duplicates-pls',
         data: 'just some data'
       }).then(itRunsSuccessfully).catch(function(err) {
         console.log(err);

--- a/tests/int/index.js
+++ b/tests/int/index.js
@@ -271,14 +271,14 @@ describe('couch2pg', function() {
     });
 
     it('should handle a doc update', function() {
-      var doc;
+      var doc = {
+        _id: '54contact:person:create\u00004form:contact:person:create',
+        data: '\u00004form:contact:person:create\u0000fndjskf'
+      };
       return couchdb
-        .put({
-          _id: '54contact:person:create\u00004form:contact:person:create',
-          data: '\u00004form:contact:person:create\u0000fndjskf'
-        })
+        .put(doc)
         .then(function(result) {
-          doc = result;
+          doc._rev = result.rev;
           return itRunsSuccessfully();
         })
         .then(function() {
@@ -290,7 +290,6 @@ describe('couch2pg', function() {
           console.log(err);
           throw new Error(err);
         });
-
     });
   });
 });

--- a/tests/int/index.js
+++ b/tests/int/index.js
@@ -239,5 +239,15 @@ describe('couch2pg', function() {
         throw new Error(err);
       });
     });
+
+    it('should handle documents with \u0000 in their IDs', function() {
+      return couchdb.put({
+        _id: '\u0000MyID\u0000not-escaped',
+        data: 'just some data'
+      }).then(itRunsSuccessfully).catch(function(err) {
+        console.log(err);
+        throw new Error(err);
+      });
+    });
   });
 });

--- a/tests/int/index.js
+++ b/tests/int/index.js
@@ -242,8 +242,28 @@ describe('couch2pg', function() {
 
     it('should handle documents with \u0000 in their IDs', function() {
       return couchdb.put({
-        _id: '\u0000MyID\u0000not-escaped',
+        _id: '54collect_off\u00004form:collect_off\u0000\u0000',
         data: 'just some data'
+      }).then(itRunsSuccessfully).catch(function(err) {
+        console.log(err);
+        throw new Error(err);
+      });
+    });
+
+    it('should handle documents with \u0000 in their IDs, or sneakier times 2', function() {
+      return couchdb.put({
+        _id: '54collect_off\\\u00004form:collect_off\\\\u0000\\\\u0000',
+        data: 'just some data'
+      }).then(itRunsSuccessfully).catch(function(err) {
+        console.log(err);
+        throw new Error(err);
+      });
+    });
+
+    it('should handle documents with \u0000 in their and their data', function() {
+      return couchdb.put({
+        _id: '54contact:person:create\u00004form:contact:person:create\u0000\u0000-info',
+        data: '\u00004form:contact:person:create\u0000fndjskf'
       }).then(itRunsSuccessfully).catch(function(err) {
         console.log(err);
         throw new Error(err);

--- a/tests/int/index.js
+++ b/tests/int/index.js
@@ -270,20 +270,28 @@ describe('couch2pg', function() {
       });
     });
 
-    it('should handle a doc update', function() {
-      var doc = {
+    it('should handle doc updates / deletes', function() {
+      var docs = [ {
         _id: '54contact:person:create\u00004form:contact:person:create',
         data: '\u00004form:contact:person:create\u0000fndjskf'
-      };
+      }, {
+        _id: '54contact:person:create\\\\u00004form:contact:person:create-bis',
+        data: '\u00004form:contact:person:create\u0000fndjskf'
+      }, {
+        _id: '54contact:person:create\\\\u00004form:contact:person:create-bis-bis',
+        data: '\u00004form:contact:person:create\u0000fndjskf'
+      }];
       return couchdb
-        .put(doc)
+        .bulkDocs(docs)
         .then(function(result) {
-          doc._rev = result.rev;
+          result.forEach(function(result, key) {
+            docs[key]._rev = result.rev;
+          });
           return itRunsSuccessfully();
         })
         .then(function() {
-          doc.data += 'updated';
-          return couchdb.put(doc);
+          docs[2]._deleted = true;
+          return couchdb.bulkDocs(docs);
         })
         .then(itRunsSuccessfully)
         .catch(function(err) {


### PR DESCRIPTION
pg-format library doesn't successfully escape unicode null characters (\u0000) in strings, cause importer to crash when trying to delete docs whose IDs contain unicode null characters.